### PR TITLE
Fix for reset function to scale back to original image

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ class PhotoViewManager {
     this._manager.off('zoom');
   }
 
-  reset({ animate = false } = {}) {
+  reset(animate) {
     if(animate) {
        this._setTransition(true);
        this._transform(0, 0, 1);
@@ -229,12 +229,11 @@ class PhotoView {
         new PhotoViewManager(options).init(item)
       );
     });
-
   }
 
-  reset() {
+  reset({ animate = false } = {}) {
     this.instances.forEach(photoViewInstance => {
-      photoViewInstance.reset();
+      photoViewInstance.reset(animate);
     });
   }
 


### PR DESCRIPTION
### Why:
Currently the reset function only affects the css property for transform, but does not actually reset the scale of the instance back to 1. This updated function should do that.

### Fix: 
Passing argument to PhotoViewManager instead of PhotoView which the instances are created of. 